### PR TITLE
Load the page from simple.wikipedia if it exists, otherwise from mdwiki

### DIFF
--- a/modules/mw.cx.init.Translation.js
+++ b/modules/mw.cx.init.Translation.js
@@ -275,6 +275,18 @@ mw.cx.init.Translation.prototype.fetchSourcePageContent_mdwiki = async function 
 	// Manual normalisation to avoid redirects on spaces but not to break namespaces
 	const title = wikiPage.getTitle().replace(/ /g, '_')
 
+	const simple_url = "https://cxserver.wikimedia.org/v2/page/simple/" + targetLanguage + "/User:Mr.%20Ibrahem%2F" + title;
+
+	const simple_result = await fetch(simple_url)
+		.then((response) => {
+			if (response.ok) {
+				return response.json();
+			}
+		})
+
+	if (simple_result) {
+		return simple_result;
+	}
 	const fetchParams = {
 		sourcelanguage: "mdwiki",
 		targetlanguage: targetLanguage,


### PR DESCRIPTION
Load the page from simple.wikipedia if it exists, otherwise from mdwiki

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced asynchronous data fetching for improved performance when retrieving content from wiki pages.
	- Enhanced the method for constructing API URLs, streamlining the data retrieval process based on target language and page titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->