### PR TITLE
Enhance Campaign Support in Translation Modules

### DIFF
--- a/includes/ActionApi/ApiContentTranslationPublish.php
+++ b/includes/ActionApi/ApiContentTranslationPublish.php
@@ -138,6 +138,7 @@ class ApiContentTranslationPublish extends ApiBase {
 				'user' => $user_name,
 				'summary' => $summary,
 				'target' => $params['to'],
+				'campaign' => $params['campaign'],
 				'sourcetitle' => $params['sourcetitle'],
 			];
 
@@ -403,6 +404,7 @@ class ApiContentTranslationPublish extends ApiBase {
 				ParamValidator::PARAM_ISMULTI => true,
 			],
 			/** @todo These should be renamed to something all-lowercase and lacking a "wp" prefix */
+			'campaign' => null,
 			'wpCaptchaId' => null,
 			'wpCaptchaWord' => null,
 			'cxversion' => [

--- a/modules/mw.cx.TargetArticle.js
+++ b/modules/mw.cx.TargetArticle.js
@@ -8,12 +8,16 @@
  * @param {ve.init.mw.CXTarget} veTarget
  * @param {Object} config Translation configuration
  * @param {mw.cx.SiteMapper} config.siteMapper SiteMapper instance
+ * @param {string} config.campaign Campaign name for targeting purposes
  */
 mw.cx.TargetArticle = function MWCXTargetArticle( translation, veTarget, config ) {
 	this.translation = translation;
 	this.veTarget = veTarget;
 	this.config = config;
 	this.siteMapper = config.siteMapper;
+	this.campaign = config.campaign;
+
+	console.log('MWCXTargetArticle: campaign: ' + this.campaign);
 	this.sourceTitle = translation.getSourceTitle();
 	this.sourceLanguage = translation.getSourceLanguage();
 	this.targetLanguage = translation.getTargetLanguage();
@@ -146,6 +150,7 @@ mw.cx.TargetArticle.prototype.publish = function ( hasIssues, hasTooMuchUnmodifi
 			title: this.getTargetTitle(),
 			// user: mw.user.getName(),
 			html,
+			campaign: this.campaign,
 			categories: this.getTargetCategories( hasTooMuchUnmodifiedText ),
 			publishtags: this.getTags( hasTooMuchUnmodifiedText ),
 			wpCaptchaId: this.captcha && this.captcha.id,
@@ -226,7 +231,7 @@ mw.cx.TargetArticle.prototype.publishSuccess = function ( response, jqXHR ) {
 				lang: this.targetLanguage,
 				sourcetitle: this.sourceTitle,
 				title: this.getTargetTitle(),
-				// campaign: campaign
+				campaign: this.campaign
 			};
 			var url = "https://mdwiki.toolforge.org/Translation_Dashboard/publish/index.php";
 			window.open( url + '?' + $.param( pp ), '_blank' );

--- a/modules/mw.cx.TranslationController.js
+++ b/modules/mw.cx.TranslationController.js
@@ -14,6 +14,7 @@
 mw.cx.TranslationController = function MwCxTranslationController(
 	translation, veTarget, siteMapper, config
 ) {
+	this.config = config;
 	this.translation = translation;
 	this.veTarget = veTarget;
 	this.siteMapper = siteMapper;
@@ -41,7 +42,8 @@ mw.cx.TranslationController = function MwCxTranslationController(
 	}
 
 	this.targetArticle = new mw.cx.TargetArticle( this.translation, this.veTarget, {
-		siteMapper: this.siteMapper
+		siteMapper: this.siteMapper,
+		campaign: this.config.campaign
 	} );
 	this.translationTracker = new mw.cx.TranslationTracker( this.veTarget, config );
 	this.saveScheduler = OO.ui.debounce( this.processSaveQueue.bind( this ), 5 * 1000 );

--- a/modules/mw.cx.init.js
+++ b/modules/mw.cx.init.js
@@ -63,6 +63,7 @@
 		services.requestManager = new mw.cx.MwApiRequestManager( mw.cx.sourceLanguage, mw.cx.targetLanguage, services.siteMapper );
 		services.MTService = new mw.cx.MachineTranslationService( mw.cx.sourceLanguage, mw.cx.targetLanguage, services.siteMapper );
 		services.MTManager = new mw.cx.MachineTranslationManager( mw.cx.sourceLanguage, mw.cx.targetLanguage, services.MTService );
+		services.campaign = query.campaign;
 
 		getTargetTitle( query.targettitle, sourceTitle, services.MTService ).then( function ( targetTitle ) {
 			const sourceWikiPage = new mw.cx.dm.WikiPage( sourceTitle, mw.cx.sourceLanguage, sourceRevision, sourceSectionTitle );


### PR DESCRIPTION
### **Description**
- Introduced support for a `campaign` parameter across multiple modules.
- Enhanced error handling for JSON parsing in `TranslationMdwiki`.
- Updated API to handle campaign information during content translation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mw.cx.TargetArticle.js</strong><dd><code>Enhance TargetArticle with Campaign Support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/mw.cx.TargetArticle.js
<li>Added <code>campaign</code> parameter to the constructor.<br> <li> Logged the campaign name for debugging purposes.<br> <li> Included campaign in the publish method parameters.<br>


</details>


  </td>
  <td><a href="https://github.com/MrIbrahem/cx/pull/15/files#diff-f9acdefe9ee6f648b118dee674f193ec6dc311b2b9a517aea7c8a40380622aa4">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>mw.cx.TranslationController.js</strong><dd><code>Integrate Campaign in TranslationController</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/mw.cx.TranslationController.js
- Passed `campaign` from config to TargetArticle.



</details>


  </td>
  <td><a href="https://github.com/MrIbrahem/cx/pull/15/files#diff-2c2f24bd6a0cb23bdba7fb5ab8344a69ca570f4c31f65e0aa158af94da380aca">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>mw.cx.TranslationMdwiki.js</strong><dd><code>Enhance Error Handling in TranslationMdwiki</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/mw.cx.TranslationMdwiki.js
- Improved error handling for JSON parsing.



</details>


  </td>
  <td><a href="https://github.com/MrIbrahem/cx/pull/15/files#diff-d8aab00b6f1438a40d847cb8dd42dd50fd9ca3353db81d4dee3e33732425f7db">+15/-9</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>mw.cx.init.js</strong><dd><code>Initialize Campaign in Services</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/mw.cx.init.js
- Added `campaign` to services initialization.



</details>


  </td>
  <td><a href="https://github.com/MrIbrahem/cx/pull/15/files#diff-ab9f5a21056be4b0a6ceef27b17545a19bd9fd456904e102fe6cb6317786ea1a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>ApiContentTranslationPublish.php</strong><dd><code>Add Campaign Parameter to API Content Translation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

includes/ActionApi/ApiContentTranslationPublish.php
<li>Included <code>campaign</code> in the parameters for saving wikitext.<br> <li> Updated allowed parameters to include <code>campaign</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/MrIbrahem/cx/pull/15/files#diff-53ab7eedb43b25e35ef761111e8c080824453b5f981a9564a55c8b786df2496f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `campaign` parameter across various components to enhance tracking and categorization capabilities.
	- Updated the `TargetArticle` and `TranslationController` to utilize campaign-specific data for improved functionality.
- **Bug Fixes**
	- Enhanced error handling in HTML content fetching and JSON parsing to prevent crashes from malformed data.
- **Chores**
	- Streamlined code for clarity and improved promise handling in the HTML fetching process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->